### PR TITLE
fix typo in exercise-1-3.tex

### DIFF
--- a/exercise/exercise-1-3.tex
+++ b/exercise/exercise-1-3.tex
@@ -24,7 +24,7 @@
   
 \item 準備練習
   \begin{enumerate}
-  \item ベクトルや行列を扱うためのユーティリティー関数が({\tt cmatrix\.h})に用意されている。サンプルプログラム{\tt matrix\_example.c}や行列・行列積を計算するプログラム{\tt multiply.c}の中身を見て、その使い方を確認せよ
+  \item ベクトルや行列を扱うためのユーティリティー関数が({\tt cmatrix.h})に用意されている。サンプルプログラム{\tt matrix\_example.c}や行列・行列積を計算するプログラム{\tt multiply.c}の中身を見て、その使い方を確認せよ
   \item LU分解のサンプルプログラム({\tt lu\_decomp.c})をコンパイル・実行せよ。コンパイル時にLAPACKをリンク({\tt -llapack})する必要があることに注意(ハンドブック3.1.6節)
     \begin{quote} \tt
       \$ \underline{cc lu\_decomp.c -o lu\_decomp -llapack} \\


### PR DESCRIPTION
This is my first pull request. I found one typo in the handout today, then I made this pull request just for practice.